### PR TITLE
Fixed CA engine violations with TemporaryRecipeDataAccessObject

### DIFF
--- a/src/app/RecommendUseCaseFactory.java
+++ b/src/app/RecommendUseCaseFactory.java
@@ -1,12 +1,12 @@
 package app;
 
-import data_access.TemporaryRecipeDataAccessObject;
 import entity.NutritionDataFactory;
 import entity.RecipeFactory;
 import entity.RecipeInfoFactory;
 import interface_adapter.DisplayViewModel;
 import interface_adapter.recommend.RecommendController;
 import interface_adapter.recommend.RecommendPresenter;
+import use_case.TemporaryRecipeDataAccessInterface;
 import use_case.recommend.RecommendDataAccessInterface;
 import use_case.recommend.RecommendInputBoundary;
 import use_case.recommend.RecommendInteractor;
@@ -19,7 +19,7 @@ public class RecommendUseCaseFactory {
 
     private RecommendUseCaseFactory() {}
 
-    public static RecommendController create(RecommendDataAccessInterface dataAccessObject, TemporaryRecipeDataAccessObject temporaryRecipeDataAccessObject, DisplayViewModel displayViewModel) {
+    public static RecommendController create(RecommendDataAccessInterface dataAccessObject, TemporaryRecipeDataAccessInterface temporaryRecipeDataAccessObject, DisplayViewModel displayViewModel) {
 
         try {
             RecommendController recommendController = createRecommendUseCase(dataAccessObject, temporaryRecipeDataAccessObject, displayViewModel);
@@ -31,7 +31,7 @@ public class RecommendUseCaseFactory {
         return null;
     }
 
-    private static RecommendController createRecommendUseCase(RecommendDataAccessInterface dataAccessObject, TemporaryRecipeDataAccessObject temporaryRecipeDataAccessObject, DisplayViewModel displayViewModel) throws IOException {
+    private static RecommendController createRecommendUseCase(RecommendDataAccessInterface dataAccessObject, TemporaryRecipeDataAccessInterface temporaryRecipeDataAccessObject, DisplayViewModel displayViewModel) throws IOException {
 
         RecommendOutputBoundary recommendOutputBoundary = new RecommendPresenter(displayViewModel);
 

--- a/src/data_access/RecipeDataAccessObject.java
+++ b/src/data_access/RecipeDataAccessObject.java
@@ -25,7 +25,6 @@ public class RecipeDataAccessObject implements BrowseDataAccessInterface, Recomm
     private final Map<String, Recipe> savedRecipes = new HashMap<>();
 
 
-    @Override
     public ArrayList<Recipe> browse(BrowseFilter browseFilter) {
         String url = getBrowseUrl(browseFilter);
         return searchRecipes(url);

--- a/src/data_access/TemporaryRecipeDataAccessObject.java
+++ b/src/data_access/TemporaryRecipeDataAccessObject.java
@@ -4,13 +4,14 @@ import entity.NutritionDataFactory;
 import entity.Recipe;
 import entity.RecipeFactory;
 import entity.RecipeInfoFactory;
+import use_case.TemporaryRecipeDataAccessInterface;
 import use_case.browse.BrowseInputData;
 
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
 
-public class TemporaryRecipeDataAccessObject {
+public class TemporaryRecipeDataAccessObject implements TemporaryRecipeDataAccessInterface  {
 
     private final Map<Integer, Recipe> recipes = new HashMap<>();
 
@@ -19,10 +20,6 @@ public class TemporaryRecipeDataAccessObject {
 
     public Recipe getFromID(int id) {
         return recipes.get(id);
-    }
-
-    public void storeRecipe(Recipe recipe) {
-        recipes.put(recipe.getID(), recipe);
     }
 
     public void storeRecipes(ArrayList<Recipe> recipeList) {

--- a/src/use_case/TemporaryRecipeDataAccessInterface.java
+++ b/src/use_case/TemporaryRecipeDataAccessInterface.java
@@ -1,0 +1,14 @@
+package use_case;
+
+import entity.Recipe;
+import entity.RecommendFilter;
+
+import java.util.ArrayList;
+
+public interface TemporaryRecipeDataAccessInterface {
+
+    Recipe getFromID(int id);
+
+    void storeRecipes(ArrayList<Recipe> recipeList);
+
+}

--- a/src/use_case/recommend/RecommendInteractor.java
+++ b/src/use_case/recommend/RecommendInteractor.java
@@ -1,6 +1,5 @@
 package use_case.recommend;
 
-import data_access.TemporaryRecipeDataAccessObject;
 import entity.*;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
@@ -8,6 +7,7 @@ import okhttp3.Response;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
+import use_case.TemporaryRecipeDataAccessInterface;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -17,14 +17,14 @@ import java.util.Map;
 public class RecommendInteractor implements RecommendInputBoundary {
 
     final RecommendDataAccessInterface dataAccessObject;
-    final TemporaryRecipeDataAccessObject temporaryRecipeDataAccessObject;
+    final TemporaryRecipeDataAccessInterface temporaryRecipeDataAccessObject;
     final RecommendOutputBoundary recommendPresenter;
     final RecipeFactory recipeFactory;
     final RecipeInfoFactory recipeInfoFactory;
     final NutritionDataFactory nutritionDataFactory;
 
     public RecommendInteractor(RecommendDataAccessInterface dataAccessInterface,
-                               TemporaryRecipeDataAccessObject temporaryRecipeDataAccessObject,
+                               TemporaryRecipeDataAccessInterface temporaryRecipeDataAccessObject,
                                RecommendOutputBoundary recommendOutputBoundary,
                                RecipeFactory recipeFactory,
                                RecipeInfoFactory recipeInfoFactory,


### PR DESCRIPTION
All places that made use of TemporaryRecipeDataAccessObject (except for main) has been modified so that they use TemporaryRecipeDataAccessInterface instead. After changes were made, the code no longer violates the CA engine, as the interactor accesses the DataAccessInterface instead of the DataAccessObject now.