### PR TITLE
Fixed API bug

### DIFF
--- a/src/data_access/RecipeDataAccessObject.java
+++ b/src/data_access/RecipeDataAccessObject.java
@@ -119,13 +119,13 @@ public class RecipeDataAccessObject implements BrowseDataAccessInterface, Recomm
         return getJsonArrayRecipesFromApi(url);
     }
 
-    private JSONArray makeGetRecipeInformationBulkApiCall (ArrayList<String> ids) {
+    private JSONArray makeGetRecipeInformationBulkApiCall(ArrayList<String> ids) {
         //build the url request of getting recipe information bulk from the API
         StringBuilder urlBuilder
                 = new StringBuilder("https://api.spoonacular.com/recipes/informationBulk");
         urlBuilder.append("?apiKey=").append(API_KEY);       //add api key to the request url to get authentication
         urlBuilder.append("&fillIngredients=true").append("&addRecipeInformation=true")
-                .append("&addRecipeNutrition=true"); //make sure the response will contain ingredients, recipeInfo, and nutrition
+                .append("&includeNutrition=true"); //make sure the response will contain ingredients, recipeInfo, and nutrition
 
         //add the recipe ids we want to search for to the link
         String stringOfIds = "&ids=" + String.join(",", ids);


### PR DESCRIPTION
Before fixing the bug, when the "Similar Recipes" button is clicked an error message is displayed since the API cannot find the nutrition information of the searched recipe. After fixing the bug, the similar recipes are successfully displayed.